### PR TITLE
codeql: extend metrics enum access query

### DIFF
--- a/contrib/codeql/nightly/MetricsEnumAccess.ql
+++ b/contrib/codeql/nightly/MetricsEnumAccess.ql
@@ -1,5 +1,5 @@
 /**
- * @name Metrics Enum Access Issue
+ * @name Metrics Enum Access Issues
  * @id asymmetric-research/metrics-enum-access
  * @description Finds issues with FD_METRICS_ENUM_%_CNT and FD_METRICS_ENUM_%_IDX macros used for array accesses.
  * @kind problem
@@ -8,72 +8,244 @@
  */
 
 import cpp
-
+import semmle.code.cpp.dataflow.new.DataFlow
 
 bindingset[s]
-int getValue(string s) {
-    result = s.regexpCapture(".*?([0-9]+).*", 1).toInt()
+int getValue(string s) { result = s.regexpCapture(".*?([0-9]+).*", 1).toInt() }
+
+/**
+ * Gets the 0-based dimension of the array access expression.
+ * E.g., for `a[i]`, returns 0; for `a[i][j]`, returns 1.
+ */
+int getDimension(ArrayExpr e) {
+  if e.getArrayBase() instanceof ArrayExpr
+  then result = 1 + getDimension(e.getArrayBase().(ArrayExpr))
+  else result = 0
 }
 
-predicate defMacro(Variable f, MacroAccess m) {
-    m.getMacroName().matches("FD_METRICS_ENUM_%_CNT") and
-    f.getLocation().getStartLine() = m.getLocation().getStartLine() and
-    f.getLocation().getFile() = m.getLocation().getFile()
+/**
+ * Gets the 1-based number of dimensions of the array type.
+ * E.g., for `int a[3][4]`, returns 2.
+ */
+private int getNumArrayDimensions(ArrayType at) {
+  if at.getBaseType() instanceof ArrayType
+  then result = 1 + getNumArrayDimensions(at.getBaseType().(ArrayType))
+  else result = 1
 }
 
-class MetricsEnumArray extends Variable {
-    MetricsEnumArray() {
-        this.getType() instanceof ArrayType and
-        defMacro(this, _)
-    }
-
-    MacroAccess getMacroAccess() {
-        defMacro(this, result)
-    }
-
-    ArrayExpr getAUsage() {
-        this.getAnAccess() = result.getAChild()
-    }
+pragma[inline]
+Literal nextLiteral(Element l) {
+  min(Literal li |
+    afterElement(l.getLocation(), li)
+  |
+    li order by li.getLocation().getStartLine(), li.getLocation().getStartColumn()
+  ) = result
 }
 
-predicate accMacro(ArrayExpr a, MacroAccess m) {
-    m.getMacroName().matches("FD_METRICS_ENUM_%_IDX") and
-    inmacroexpansion(a.getArrayOffset(), m)
+Literal nthLiteralAfterVariable(ArrayVariable v, int n) {
+  (
+    n = 0 and result = nextLiteral(v)
+    or
+    n > 0 and result = nextLiteral(nthLiteralAfterVariable(v, n - 1))
+  ) and
+  n < getNumArrayDimensions(v.getType())
 }
 
+/** Holds if `e` starts strictly after `f` textually. */
+pragma[inline]
+predicate afterElement(Location f, Element e) {
+  e.getLocation().getFile() = f.getFile() and
+  e.getLocation().getStartLine() >= f.getStartLine() and
+  e.getLocation().getStartColumn() > f.getStartColumn()
+}
+
+/**
+ * Matches macros of the form `FD_METRICS_TYPE_<TYPE>` where `<TYPE>` is a
+ * string representing the metric type, e.g., `GAUGE`, `COUNTER`, etc.
+ */
+class FdMetricsTypeMacro extends Macro {
+  FdMetricsTypeMacro() { this.getName().matches("FD_METRICS_TYPE_%") }
+
+  string getType() { result = this.getName().regexpCapture("FD_METRICS_TYPE_(.*)", 1) }
+}
+
+/**
+ * Matches macros of the form `FD_METRICS_<???>_CNT`.
+ */
+abstract class FdMetricsCountMacro extends Macro {
+  /** Returns the enum name, iff this macro is associated with an enum. */
+  abstract string getAnEnumName();
+}
+
+/**
+ * Matches macros of the form `FD_METRICS_<TYPE>_<???>_CNT` where `<TYPE>` is from `FdMetricsTypeMacro` and does not include enums.
+ * E.g., `FD_METRICS_COUNTER_<NAME>_CNT`, `FD_METRICS_GAUGE_<NAME>_CNT`, etc.
+ */
+class FdMetricsTypeCountMacro extends FdMetricsCountMacro {
+  string type;
+  string groupMeasurement;
+
+  FdMetricsTypeCountMacro() {
+    type =
+      this.getName()
+          .regexpCapture("FD_METRICS_(" + any(FdMetricsTypeMacro m).getType() + ").*_CNT", 1) and
+    groupMeasurement = this.getName().regexpCapture("FD_METRICS_" + type + "_(.*)_CNT", 1)
+  }
+
+  override string getAnEnumName() {
+    exists(FdDeclareMetricEnumInvocation inv |
+      inv.getEnumName() = result and
+      inv.getType() = type and
+      inv.getGroupMeasurement() = groupMeasurement
+    )
+  }
+}
+
+/**
+ * Matches macros of the form `FD_METRICS_ENUM_<ENUM_NAME>_CNT`.
+ */
+class FdMetricsEnumCountMacro extends FdMetricsCountMacro {
+  FdMetricsEnumCountMacro() { this.getName().matches("FD_METRICS_ENUM_%_CNT") }
+
+  override string getAnEnumName() {
+    result = this.getName().regexpCapture("FD_METRICS_ENUM_(.*?)_CNT$", 1)
+  }
+}
+
+/**
+ * Matches macros of the form `FD_METRICS_ENUM_<ENUM_NAME>_IDX`
+ */
+class FdMetricsEnumIndexMacro extends Macro {
+  FdMetricsEnumIndexMacro() { this.getName().matches("FD_METRICS_ENUM_%_IDX") }
+
+  string getEnumName() { result = this.getName().regexpCapture("FD_METRICS_ENUM_(.*?)_V_.*$", 1) }
+
+  FdMetricsEnumCountMacro asCnt() { result.getAnEnumName() = this.getEnumName() }
+}
+
+class FdDeclareMetricEnumMacro extends Macro {
+  FdDeclareMetricEnumMacro() { this.hasName("DECLARE_METRIC_ENUM") }
+}
+
+/**
+ * Matches invocations of the `DECLARE_METRIC_ENUM` macro.
+ */
+class FdDeclareMetricEnumInvocation extends MacroInvocation {
+  FdDeclareMetricEnumInvocation() { this.getMacro() instanceof FdDeclareMetricEnumMacro }
+
+  string getGroupMeasurement() { result = this.getUnexpandedArgument(0) }
+
+  string getType() { result = this.getUnexpandedArgument(1) }
+
+  string getEnumName() { result = this.getUnexpandedArgument(2) }
+}
+
+/**
+ * Matches variable declarations of array type.
+ */
+class ArrayVariable extends Variable {
+  ArrayVariable() { this.getType() instanceof ArrayType }
+}
+
+/**
+ * Matches variable declarations of array type used in metrics.
+ */
+class MetricsArray extends ArrayVariable {
+  FdMetricsCountMacro macro;
+
+  MetricsArray() {
+    // there is no direct way to get the macro used in the array size expression,
+    // so we look for the dimension-th literal after the field declaration...
+    // and check if that literal is the argument to a macro invocation of the right kind
+    // this would break if one dimension is defined using something other than a literal,
+    // for example, `2 * 2` ...
+    nthLiteralAfterVariable(this, _) = macro.getAnInvocation().getExpr()
+  }
+
+  ArrayExpr getAUsage(int dimension) {
+    this.getAnAccess() = result.getArrayBase*() and dimension = getDimension(result)
+  }
+
+  FdMetricsCountMacro getMacro(int dimension) {
+    nthLiteralAfterVariable(this, dimension) = result.getAnInvocation().getExpr()
+  }
+}
+
+/**
+ * Matches array expressions that use `FD_METRICS_ENUM_<METRIC>_IDX` macros as their index or
+ * where the index is bounded by a `FD_METRICS_<???>_CNT` macro.
+ */
 class MetricsEnumAccess extends ArrayExpr {
-    MetricsEnumAccess() {
-        accMacro(this, _)
-    }
+  FdMetricsCountMacro macro;
 
-    MacroAccess getMacroAccess() {
-        accMacro(this, result)
-    }
+  MetricsEnumAccess() {
+    (
+      exists(FdMetricsEnumIndexMacro idxMacro |
+        this.getArrayOffset() = idxMacro.getAnInvocation().getExpr() and
+        macro = idxMacro.asCnt()
+      )
+      or
+      exists(LTExpr ltExpr | ltExpr.getRightOperand() = macro.getAnInvocation().getExpr() |
+        DataFlow::localExprFlow(ltExpr.getLeftOperand(), this.getArrayOffset())
+      )
+    )
+  }
+
+  FdMetricsCountMacro getMacro() { result = macro }
 }
 
-Macro idxToCnt(Macro idxMacro) {
-    result.hasName(idxMacro.getName().regexpReplaceAll("_V_.*", "_CNT"))
+/**
+ * Holds if the CNT value associated with the index in `a` does not match the array size
+ * of the array being accessed.
+ */
+predicate isMismatchedCount(MetricsEnumAccess a) {
+  getValue(a.getMacro().getBody()) != a.getArrayBase().getType().(ArrayType).getArraySize()
 }
 
-predicate matchLiteralDef(MetricsEnumAccess a) {
-    getValue(idxToCnt(a.getMacroAccess().getMacro()).getBody()) != a.getArrayBase().getType().(ArrayType).getArraySize()
+/**
+ * Holds if the index used in `a` (which is either an IDX macro or a value bounded by a CNT macro)
+ * is out of bounds for the array being accessed.
+ */
+predicate isArrayAccessOob(ArrayExpr access) {
+  exists(MetricsArray e, int dimension, int enumArraySize, int arrayIndex |
+    dimension = getDimension(access) and
+    getValue(access.getArrayOffset().getValue()) = arrayIndex and
+    getValue(e.getMacro(dimension).getBody()) = enumArraySize and
+    e.getAUsage(dimension) = access and
+    enumArraySize <= arrayIndex
+  )
 }
 
-ArrayExpr matchLiteralAccess(MetricsEnumArray e) {
-    result = e.getAUsage() and
-    getValue(e.getMacroAccess().getMacro().getBody()) <= getValue(result.getArrayOffset().getValue())
+/**
+ * Holds if the index used in `a` (which is either an IDX macro or a value bounded by a CNT macro)
+ * does not match any metric array definition's associated enum name (if any).
+ * E.g., if `a` uses `FD_METRICS_ENUM_FOO_IDX`, but the array size is defined using
+ * the literal `9` (instead of `FD_METRICS_ENUM_FOO_CNT`), then this predicate holds.
+ */
+predicate isMismatchedEnumName(MetricsEnumAccess a) {
+  exists(int dimension | dimension = getDimension(a) |
+    not exists(MetricsArray e |
+      e.getAUsage(dimension) = a and
+      e.getMacro(dimension).getAnEnumName() = a.getMacro().getAnEnumName()
+    )
+  )
 }
 
-predicate matchMetricType(MetricsEnumAccess a, MetricsEnumArray e) {
-    e.getAUsage() = a and
-    idxToCnt(a.getMacroAccess().getMacro()) != e.getMacroAccess().getMacro()
-}
-
-
-from Element res, MetricsEnumAccess a, MetricsEnumArray e, string des
+from ArrayExpr access, string des
 where
-    res = matchLiteralAccess(e) and des = "literal access greater than the arrays size" or
-    res = a and matchLiteralDef(a) and des = "literal array definition size differing from the metrics cnt" or
-    res = e and matchMetricType(a, e) and des = "metrics idx and count types do not match"
-select res, des
-
+  isArrayAccessOob(access) and
+  des =
+    "The IDX value (" + access.getArrayOffset().getValue() + ") is greater than the arrays size (" +
+      access.getArrayBase().getType().(ArrayType).getArraySize() + ")."
+  or
+  isMismatchedCount(access) and
+  des =
+    "The CNT value (" + access.(MetricsEnumAccess).getMacro().getBody() +
+      ") associated with the IDX macro and the array size (" +
+      access.getArrayBase().getType().(ArrayType).getArraySize() +
+      ") do not match and could result in under/over reads/writes."
+  or
+  isMismatchedEnumName(access) and
+  des =
+    "The enum name in the IDX macro does not match the one associated with the CNT macro (if any) in the array definition."
+select access, des

--- a/contrib/codeql/test/query-tests/MetricsEnumAccess/MetricsEnumAccess.c
+++ b/contrib/codeql/test/query-tests/MetricsEnumAccess/MetricsEnumAccess.c
@@ -1,0 +1,135 @@
+typedef unsigned long ulong;
+volatile ulong *fd_metrics_tl;
+
+#define FD_METRICS_TYPE_GAUGE (0UL)
+#define FD_METRICS_TYPE_COUNTER (1UL)
+#define FD_METRICS_TYPE_HISTOGRAM (2UL)
+
+#define FD_METRICS_CONVERTER_NONE (0UL)
+#define FD_METRICS_CONVERTER_SECONDS (1UL)
+#define FD_METRICS_CONVERTER_NANOSECONDS (2UL)
+
+#define DECLARE_METRIC_ENUM(MEASUREMENT, TYPE, ENUM_NAME, ENUM_VARIANT) {  \
+    .name = FD_METRICS_##TYPE##_##MEASUREMENT##_NAME,                      \
+    .enum_name = FD_METRICS_ENUM_##ENUM_NAME##_NAME,                       \
+    .enum_variant = FD_METRICS_ENUM_##ENUM_NAME##_V_##ENUM_VARIANT##_NAME, \
+    .type = FD_METRICS_TYPE_##TYPE,                                        \
+    .desc = FD_METRICS_##TYPE##_##MEASUREMENT##_DESC,                      \
+    .offset = FD_METRICS_##TYPE##_##MEASUREMENT##_OFF +                    \
+              FD_METRICS_ENUM_##ENUM_NAME##_V_##ENUM_VARIANT##_IDX,        \
+    .converter = FD_METRICS_##TYPE##_##MEASUREMENT##_CVT}
+
+#define MIDX(type, group, measurement) (FD_METRICS_##type##_##group##_##measurement##_OFF)
+
+#define FD_MCNT_ENUM_COPY(group, measurement, values)                                \
+    do                                                                               \
+    {                                                                                \
+        ulong __fd_metrics_off = MIDX(COUNTER, group, measurement);                  \
+        for (ulong i = 0; i < FD_METRICS_COUNTER_##group##_##measurement##_CNT; i++) \
+        {                                                                            \
+            fd_metrics_tl[__fd_metrics_off + i] = values[i];                         \
+        }                                                                            \
+    } while (0)
+
+// Define the enum macros we need for testing
+#define FD_METRICS_ENUM_TEST_CNT 3
+#define FD_METRICS_ENUM_TEST_NAME "test"
+#define FD_METRICS_ENUM_TEST_V_FIRST_IDX 0
+#define FD_METRICS_ENUM_TEST_V_FIRST_NAME "first"
+#define FD_METRICS_ENUM_TEST_V_SECOND_IDX 1
+#define FD_METRICS_ENUM_TEST_V_SECOND_NAME "second"
+#define FD_METRICS_ENUM_TEST_V_THIRD_IDX 2
+#define FD_METRICS_ENUM_TEST_V_THIRD_NAME "third"
+
+// Different size than TEST enum
+#define FD_METRICS_ENUM_OTHER_CNT 5
+#define FD_METRICS_ENUM_OTHER_NAME "other"
+#define FD_METRICS_ENUM_OTHER_V_FIRST_IDX 0
+#define FD_METRICS_ENUM_OTHER_V_FIRST_NAME "first"
+#define FD_METRICS_ENUM_OTHER_V_SECOND_IDX 1
+#define FD_METRICS_ENUM_OTHER_V_THIRD_IDX 2
+#define FD_METRICS_ENUM_OTHER_V_FOURTH_IDX 3
+#define FD_METRICS_ENUM_OTHER_V_FIFTH_IDX 4
+
+#define FD_METRICS_COUNTER_BANK_TRANSACTION_RESULT_OFF (0UL)
+#define FD_METRICS_COUNTER_BANK_TRANSACTION_RESULT_NAME "bank_transaction_result"
+#define FD_METRICS_COUNTER_BANK_TRANSACTION_RESULT_TYPE (FD_METRICS_TYPE_COUNTER)
+#define FD_METRICS_COUNTER_BANK_TRANSACTION_RESULT_DESC "Result of loading and executing a transaction."
+#define FD_METRICS_COUNTER_BANK_TRANSACTION_RESULT_CVT (FD_METRICS_CONVERTER_NONE)
+#define FD_METRICS_COUNTER_BANK_TRANSACTION_RESULT_CNT (4UL)
+
+#define FD_METRICS_COUNTER_BANK_TRANSACTION_RESULT_SUCCESS_OFF (0UL)
+#define FD_METRICS_COUNTER_BANK_TRANSACTION_RESULT_ACCOUNT_IN_USE_OFF (1UL)
+#define FD_METRICS_COUNTER_BANK_TRANSACTION_RESULT_ACCOUNT_LOADED_TWICE_OFF (2UL)
+#define FD_METRICS_COUNTER_BANK_TRANSACTION_RESULT_ACCOUNT_NOT_FOUND_OFF (3UL)
+
+#define FD_METRICS_ENUM_TRANSACTION_ERROR_NAME "transaction_error"
+#define FD_METRICS_ENUM_TRANSACTION_ERROR_CNT (4UL)
+#define FD_METRICS_ENUM_TRANSACTION_ERROR_V_SUCCESS_IDX 0
+#define FD_METRICS_ENUM_TRANSACTION_ERROR_V_SUCCESS_NAME "success"
+#define FD_METRICS_ENUM_TRANSACTION_ERROR_V_ACCOUNT_IN_USE_IDX 1
+#define FD_METRICS_ENUM_TRANSACTION_ERROR_V_ACCOUNT_IN_USE_NAME "account_in_use"
+#define FD_METRICS_ENUM_TRANSACTION_ERROR_V_ACCOUNT_LOADED_TWICE_IDX 2
+#define FD_METRICS_ENUM_TRANSACTION_ERROR_V_ACCOUNT_LOADED_TWICE_NAME "account_loaded_twice"
+#define FD_METRICS_ENUM_TRANSACTION_ERROR_V_ACCOUNT_NOT_FOUND_IDX 3
+#define FD_METRICS_ENUM_TRANSACTION_ERROR_V_ACCOUNT_NOT_FOUND_NAME "account_not_found"
+
+typedef struct
+{
+    char const *name;
+    char const *enum_name;
+    char const *enum_variant;
+    int type;
+    char const *desc;
+    ulong offset;
+
+    int converter;
+} fd_metrics_meta_t;
+
+int main()
+{
+    // ISSUE 1: Out-of-bounds array access
+    // Array size is 3, but we access index 3 (which is out of bounds)
+    ulong test_array[FD_METRICS_ENUM_TEST_CNT];
+    test_array[3] = 42; // $ Alert This is out of bounds
+
+    // ISSUE 2: Mismatched count
+    // Array size is 4, but the CNT macro value is 3
+    ulong mismatched_count_array[4];
+    for (int i = 0; i < FD_METRICS_ENUM_TEST_CNT; i++)
+    {
+        mismatched_count_array[i] = i; // $ Alert
+    }
+
+    // ISSUE 3: Mismatched enum name
+    // Array sized by TEST enum, but accessed using OTHER enum
+    ulong mismatched_enum_array[FD_METRICS_ENUM_TEST_CNT];
+    mismatched_enum_array[FD_METRICS_ENUM_OTHER_V_SECOND_IDX] = 42; // $ Alert
+
+    // ISSUE 4: Counter-based array accessed using enum index
+    // Array defined with FD_METRICS_COUNTER but accessed using an enum index
+    // This is the case for arrays created with DECLARE_METRIC_ENUM
+    // and fine. But here we mismatch the enum name.
+    volatile ulong counter_array[FD_METRICS_COUNTER_BANK_TRANSACTION_RESULT_CNT];
+    counter_array[FD_METRICS_ENUM_TEST_V_FIRST_IDX] = 100; // $ Alert Mismatched enum name
+
+    // ISSUE 5: Counter-based array accessed using enum index
+    // Array defined with FD_METRICS_COUNTER but accessed using an enum index
+    // This is the case for arrays created with DECLARE_METRIC_ENUM
+    // and fine if the enum name matches.
+    volatile ulong counter_array2[FD_METRICS_COUNTER_BANK_TRANSACTION_RESULT_CNT];
+    counter_array2[FD_METRICS_ENUM_TRANSACTION_ERROR_V_SUCCESS_IDX] = 100; // OK
+
+    ulong txn_result[2];
+    FD_MCNT_ENUM_COPY(BANK, TRANSACTION_RESULT, txn_result); // $ Alert mismatched sizes, CNT (4) vs txn_result (2).
+
+    printf("Test complete\n");
+    return 0;
+}
+
+fd_metrics_meta_t ignored[] = {
+    DECLARE_METRIC_ENUM(BANK_TRANSACTION_RESULT, COUNTER, TRANSACTION_ERROR, SUCCESS),
+    DECLARE_METRIC_ENUM(BANK_TRANSACTION_RESULT, COUNTER, TRANSACTION_ERROR, ACCOUNT_IN_USE),
+    DECLARE_METRIC_ENUM(BANK_TRANSACTION_RESULT, COUNTER, TRANSACTION_ERROR, ACCOUNT_LOADED_TWICE),
+    DECLARE_METRIC_ENUM(BANK_TRANSACTION_RESULT, COUNTER, TRANSACTION_ERROR, ACCOUNT_NOT_FOUND),
+};

--- a/contrib/codeql/test/query-tests/MetricsEnumAccess/MetricsEnumAccess.expected
+++ b/contrib/codeql/test/query-tests/MetricsEnumAccess/MetricsEnumAccess.expected
@@ -1,0 +1,9 @@
+| MetricsEnumAccess.c:94:5:94:17 | access to array | The IDX value (3) is greater than the arrays size (3). |
+| MetricsEnumAccess.c:101:9:101:33 | access to array | The CNT value (3) associated with the IDX macro and the array size (4) do not match and could result in under/over reads/writes. |
+| MetricsEnumAccess.c:101:9:101:33 | access to array | The enum name in the IDX macro does not match the one associated with the CNT macro (if any) in the array definition. |
+| MetricsEnumAccess.c:107:5:107:61 | access to array | The CNT value (5) associated with the IDX macro and the array size (3) do not match and could result in under/over reads/writes. |
+| MetricsEnumAccess.c:107:5:107:61 | access to array | The enum name in the IDX macro does not match the one associated with the CNT macro (if any) in the array definition. |
+| MetricsEnumAccess.c:114:5:114:51 | access to array | The CNT value (3) associated with the IDX macro and the array size (4) do not match and could result in under/over reads/writes. |
+| MetricsEnumAccess.c:114:5:114:51 | access to array | The enum name in the IDX macro does not match the one associated with the CNT macro (if any) in the array definition. |
+| MetricsEnumAccess.c:124:49:124:59 | access to array | The CNT value ((4UL)) associated with the IDX macro and the array size (2) do not match and could result in under/over reads/writes. |
+| MetricsEnumAccess.c:124:49:124:59 | access to array | The enum name in the IDX macro does not match the one associated with the CNT macro (if any) in the array definition. |

--- a/contrib/codeql/test/query-tests/MetricsEnumAccess/MetricsEnumAccess.qlref
+++ b/contrib/codeql/test/query-tests/MetricsEnumAccess/MetricsEnumAccess.qlref
@@ -1,0 +1,2 @@
+query: MetricsEnumAccess.ql
+postprocess: InlineExpectationsTestQuery.ql


### PR DESCRIPTION
- Extend the metrics enum access query to handle multidimensional arrays which are used by fd a few times.
- Extend the query to catch mismatches related to metrics counters and gauges as well
- Extend the query to catch over/under reads/writes related to the usage of FD_MCNT_ENUM_COPY.
- Extend the query to also identify index variables `i` as accesses to a metrics array if they are bounded by `FD_METRICS_.*_CNT`, for example, when `i` is used in a loop.